### PR TITLE
correcting urls for Datacenter IP Ranges

### DIFF
--- a/microsoft-365/enterprise/urls-and-ip-address-ranges.md
+++ b/microsoft-365/enterprise/urls-and-ip-address-ranges.md
@@ -74,6 +74,12 @@ Data columns shown are:
   
 [Content delivery networks](https://support.office.com/article/content-delivery-networks-0140f704-6614-49bb-aa6c-89b75dcd7f1f)
   
-[Microsoft Azure Datacenter IP Ranges](https://www.microsoft.com/download/details.aspx?id=41653)
+[Microsoft Azure IP Ranges and Service Tags – Public Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
+
+[Microsoft Azure IP Ranges and Service Tags – US Government Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=57063)
+
+[Microsoft Azure IP Ranges and Service Tags – Germany Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=57064)
+
+[Microsoft Azure IP Ranges and Service Tags – China Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=57062)
   
 [Microsoft Public IP Space](https://www.microsoft.com/download/details.aspx?id=53602)


### PR DESCRIPTION
fixes 3817

removed the old link Microsoft Azure Datacenter IP Ranges link that went to the deprecated url. It was deprecated June 30, 2020.

added the new replacement links 

Microsoft Azure IP Ranges and Service Tags – Public Cloud
Microsoft Azure IP Ranges and Service Tags – US Government Cloud
Microsoft Azure IP Ranges and Service Tags – Germany Cloud
Microsoft Azure IP Ranges and Service Tags – China Cloud